### PR TITLE
feat: --all flag to include files, directories and their parents in heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Options:
   -c <char>, --char <char>      Use <char> to draw the bars. [default: █]
   -f <cmd>, --filter <cmd>      Filter output through <cmd> before creating the
                                 the histogram.
+  -a, --all                     Include directories and parent directories of
+                                files in the histogram. [default: false]
   -h                            Show this message.
 ```
 
@@ -58,6 +60,9 @@ Options:
 - **How do I heatmap directories instead of files?**
 
   Use `--filter 'xargs dirname'`.
+  
+  If you want to heatmap files, directories and their parent directories, use
+  `--all` instead.
   
 ## License
 

--- a/git-heatmap
+++ b/git-heatmap
@@ -36,6 +36,14 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -d|--dirs)
+      DIRS=true
+      shift
+      ;;
+    -p|--parent-dirs)
+      PARENT_DIRS=true
+      shift
+      ;;
     -h)
       cat <<EOF
 Heatmap of oft-edited files.
@@ -45,12 +53,16 @@ Usage:
 
 Options:
   -n <top>                      Limit to top <n> files. [default: 30]
-  --width <n>                   Limit histogram to <n> chars.
+  --width <n>                   Limit histogram to <n> chars. [default: 60]
   -b <branch>, --base <branch>  Compare relative to <branch>. If on <branch>,
                                 show heatmap for entire repo. [default: master]
   -c <char>, --char <char>      Use <char> to draw the bars. [default: █]
   -f <cmd>, --filter <cmd>      Filter output through <cmd> before creating the
                                 the histogram.
+  -d, --dirs                    Include directories in the heatmap.
+                                [default: false]
+  -p, --parent-dirs             Include directories and parent directories in
+                                the heatmap. [default: false]
   -h                            Show this message.
 EOF
       exit
@@ -67,6 +79,8 @@ REVIEW_BASE=${REVIEW_BASE:-master}
 CHAR=${CHAR:-█}
 WIDTH=${WIDTH:-60}
 FILTER=${FILTER:-cat -}
+DIRS=${DIRS:-false}
+PARENT_DIRS=${PARENT_DIRS:-false}
 
 files() {
   # https://stackoverflow.com/questions/7577052/

--- a/git-heatmap
+++ b/git-heatmap
@@ -88,6 +88,27 @@ files() {
     cut -f 2-
 }
 
+dirs() {
+  if [ "$DIRS" = true ] && [ "$PARENT_DIRS" = false ]; then
+    sed -e 's|/[^/]*$|/|'
+  elif [ "$DIRS" = true ] && [ "$PARENT_DIRS" = true ]; then
+    expand_parent_dirs  
+  else 
+    cat -
+  fi
+}
+
+expand_parent_dirs() {
+  while IFS= read -r file_path; do
+    echo "$file_path"
+    dir_path=$(dirname "$file_path")
+    while [[ "$dir_path" != "." ]]; do
+      echo "$dir_path/"
+      dir_path=$(dirname "$dir_path")
+    done
+  done
+}
+
 color_name() {
   if [ -t 1 ]; then
     sed -e "s/\(..*\/\)*\(.[^|]*\) |/\1$ccyan\2$cnone |/"
@@ -120,12 +141,13 @@ fi
 
 if [[ "$(git branch | grep '\*')" =~ $REVIEW_BASE ]]; then
   # If on master, show heatmap for whole repo
-  files | filter | histogram | color_name
+  files | dirs | filter | histogram | color_name
 else
   MERGE_BASE="$(git merge-base HEAD "$REVIEW_BASE")"
   files | \
     # If on separate branch, show heatmap for files changed since master
     grep -xF -f <(git diff --name-only "$MERGE_BASE") | \
+    dirs | \
     filter | \
     histogram | \
     color_name

--- a/git-heatmap
+++ b/git-heatmap
@@ -36,8 +36,8 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    -r|--recursive)
-      RECURSIVE=true
+    -a|--all)
+      ALL=true
       shift
       ;;
     -h)
@@ -55,8 +55,8 @@ Options:
   -c <char>, --char <char>      Use <char> to draw the bars. [default: █]
   -f <cmd>, --filter <cmd>      Filter output through <cmd> before creating the
                                 the histogram.
-  -r, --recursive               Also include directories and parent directories.
-                                [default: false]
+  -a, --all                     Include directories and parent directories of
+                                files in the histogram. [default: false]
   -h                            Show this message.
 EOF
       exit
@@ -81,20 +81,21 @@ files() {
     cut -f 2-
 }
 
-dirs() {
-  if  [ "$RECURSIVE" = true ]; then
+expand() {
+  if [ "$ALL" = true ]; then
     awk -F/ '
     {
-        path=$0
+        path = $0
         print path
-        split(path,parts,"/")
+        split(path, parts, "/")
         len=length(parts)
-        for(i=len;i>0;i--) {
-            dirpath=""
-            for(j=1;j<i;j++) {
-                dirpath=dirpath parts[j] "/"
+        for (i = len; i > 0; i--) {
+            dirpath = ""
+            for (j = 1; j < i; j++) {
+                dirpath = dirpath parts[j] "/"
             }
-            if(dirpath) print dirpath
+            if (dirpath) print dirpath
+            else print "."
         }
     }'
   else
@@ -134,13 +135,13 @@ fi
 
 if [[ "$(git branch | grep '\*')" =~ $REVIEW_BASE ]]; then
   # If on master, show heatmap for whole repo
-  files | dirs | filter | histogram | color_name
+  files | expand | filter | histogram | color_name
 else
   MERGE_BASE="$(git merge-base HEAD "$REVIEW_BASE")"
   files | \
     # If on separate branch, show heatmap for files changed since master
     grep -xF -f <(git diff --name-only "$MERGE_BASE") | \
-    dirs | \
+    expand | \
     filter | \
     histogram | \
     color_name

--- a/git-heatmap
+++ b/git-heatmap
@@ -36,12 +36,8 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    -d|--dirs)
-      DIRS=true
-      shift
-      ;;
-    -p|--parent-dirs)
-      PARENT_DIRS=true
+    -r|--recursive)
+      RECURSIVE=true
       shift
       ;;
     -h)
@@ -59,10 +55,8 @@ Options:
   -c <char>, --char <char>      Use <char> to draw the bars. [default: █]
   -f <cmd>, --filter <cmd>      Filter output through <cmd> before creating the
                                 the histogram.
-  -d, --dirs                    Include directories in the heatmap.
+  -r, --recursive               Also include directories and parent directories.
                                 [default: false]
-  -p, --parent-dirs             Include directories and parent directories in
-                                the heatmap. [default: false]
   -h                            Show this message.
 EOF
       exit
@@ -79,8 +73,7 @@ REVIEW_BASE=${REVIEW_BASE:-master}
 CHAR=${CHAR:-█}
 WIDTH=${WIDTH:-60}
 FILTER=${FILTER:-cat -}
-DIRS=${DIRS:-false}
-PARENT_DIRS=${PARENT_DIRS:-false}
+RECURSIVE=${RECURSIVE:-false}
 
 files() {
   # https://stackoverflow.com/questions/7577052/
@@ -89,24 +82,24 @@ files() {
 }
 
 dirs() {
-  if [ "$DIRS" = true ] && [ "$PARENT_DIRS" = false ]; then
-    sed -e 's|/[^/]*$|/|'
-  elif [ "$DIRS" = true ] && [ "$PARENT_DIRS" = true ]; then
-    expand_parent_dirs  
-  else 
+  if  [ "$RECURSIVE" = true ]; then
+    awk -F/ '
+    {
+        path=$0
+        print path
+        split(path,parts,"/")
+        len=length(parts)
+        for(i=len;i>0;i--) {
+            dirpath=""
+            for(j=1;j<i;j++) {
+                dirpath=dirpath parts[j] "/"
+            }
+            if(dirpath) print dirpath
+        }
+    }'
+  else
     cat -
   fi
-}
-
-expand_parent_dirs() {
-  while IFS= read -r file_path; do
-    echo "$file_path"
-    dir_path=$(dirname "$file_path")
-    while [[ "$dir_path" != "." ]]; do
-      echo "$dir_path/"
-      dir_path=$(dirname "$dir_path")
-    done
-  done
 }
 
 color_name() {

--- a/git-heatmap
+++ b/git-heatmap
@@ -49,7 +49,7 @@ Usage:
 
 Options:
   -n <top>                      Limit to top <n> files. [default: 30]
-  --width <n>                   Limit histogram to <n> chars. [default: 60]
+  --width <n>                   Limit histogram to <n> chars.
   -b <branch>, --base <branch>  Compare relative to <branch>. If on <branch>,
                                 show heatmap for entire repo. [default: master]
   -c <char>, --char <char>      Use <char> to draw the bars. [default: █]
@@ -88,7 +88,7 @@ expand() {
         path = $0
         print path
         split(path, parts, "/")
-        len=length(parts)
+        len = length(parts)
         for (i = len; i > 0; i--) {
             dirpath = ""
             for (j = 1; j < i; j++) {

--- a/git-heatmap
+++ b/git-heatmap
@@ -73,7 +73,7 @@ REVIEW_BASE=${REVIEW_BASE:-master}
 CHAR=${CHAR:-█}
 WIDTH=${WIDTH:-60}
 FILTER=${FILTER:-cat -}
-RECURSIVE=${RECURSIVE:-false}
+ALL=${ALL:-false}
 
 files() {
   # https://stackoverflow.com/questions/7577052/


### PR DESCRIPTION
Sometimes the content is spread across many small files in a higly hierarchical structure, and the directories heatmap is interesting too, but that can't be easily done with a filter.